### PR TITLE
Switch to DefaultCompression for png encoding

### DIFF
--- a/pkg/service/zaloa.go
+++ b/pkg/service/zaloa.go
@@ -229,7 +229,7 @@ func (z zaloaService) EncodeTile(ctx context.Context, tileImage image.Image, enc
 			return nil, fmt.Errorf("couldn't encode result image to webp: %w", err)
 		}
 	case common.TileEncoding_PNG:
-		err = (&png.Encoder{CompressionLevel: png.NoCompression}).Encode(b, tileImage)
+		err = (&png.Encoder{CompressionLevel: png.DefaultCompression}).Encode(b, tileImage)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't encode result image to png: %w", err)
 		}


### PR DESCRIPTION
I switched to NoCompression in https://github.com/tilezen/go-zaloa/pull/6 thinking that it would enable lossless compression and give more accurate output. This [disables PNG filtering](https://github.com/golang/go/blob/release-branch.go1.15/src/image/png/writer.go#L498-L508), though, so the resulting files were > 400% bigger.

This PR switches back to DefaultCompression to get back to a manageable file size.